### PR TITLE
docker: use node:current-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:current-alpine
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
This reduces the image size from 1.18GB to 0.5GB.