### PR TITLE
docker: build inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:latest
 COPY . /app
 WORKDIR /app
 
-RUN yarn install --production
+RUN yarn install
+RUN yarn build
 
 ENTRYPOINT ["node", "/app/build/index.js"]

--- a/README.md
+++ b/README.md
@@ -137,10 +137,6 @@ Options:
 ### Build
 
 ```bash
-# The docker files rely on the TS already being transpiled to JS,
-# so we first do standard install.
-yarn install
-yarn run build
 docker build -t payouts .
 ```
 


### PR DESCRIPTION
This change actually runs the build step inside the Dockerfile, whereas
previously we relied on it being run before building the image.