### PR TITLE
`commission`: list validators with comission under and above the given value

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ payouts lsNominators \
 
 ### List count of validator's commission under and above the given value
 
-```
+```bash
 payouts commission \
         -w wss://rpc.polkadot.io \
         -p 0.9
@@ -142,7 +142,7 @@ Options:
                      not using stashesFile.                              [array]
   -e, --eraDepth     How many eras prior to the last collected era to check for
                      uncollected payouts.                  [number] [default: 0]
-  -u, --suriFile
+  -u, --suriFile                                             [string] [required]
 ```
 
 **NOTES:**

--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ payouts lsNominators \
   -s 111B8CxcmnWbuDLyGvgUmRezDCK1brRZmvUuQ6SrFdMyc3S \
 ```
 
+### List count of validator's commission under and above the given value
+
+```
+payouts commission \
+        -w wss://rpc.polkadot.io \
+        -p 0.9
+```
+
 ## Options
 
 ```log
@@ -120,6 +128,8 @@ Commands:
   index.ts collect       Collect pending payouts                       [default]
   index.ts ls            List pending payouts
   index.ts lsNominators  List nominators backing the given stashes
+  index.ts commission    List validators with commission under and above the
+                         given value
 
 Options:
       --help         Show help                                         [boolean]
@@ -132,7 +142,7 @@ Options:
                      not using stashesFile.                              [array]
   -e, --eraDepth     How many eras prior to the last collected era to check for
                      uncollected payouts.                  [number] [default: 0]
-  -u, --suriFile                                             [string] [required]
+  -u, --suriFile
 ```
 
 **NOTES:**

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -101,7 +101,7 @@ export async function lsNominators({
 	});
 }
 
-export async function commision({
+export async function commission({
 	ws,
 	percent,
 }: Omit<

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -3,7 +3,12 @@ import fs from 'fs';
 
 import { isValidSeed } from './isValidSeed';
 import { log } from './logger';
-import { collectPayouts, listNominators, listPendingPayouts } from './services';
+import {
+	collectPayouts,
+	commissionData,
+	listNominators,
+	listPendingPayouts,
+} from './services';
 
 const DEBUG = process.env.PAYOUTS_DEBUG;
 
@@ -13,6 +18,7 @@ interface HandlerArgs {
 	stashesFile?: string;
 	stashes?: (string | number)[];
 	eraDepth: number;
+	percent?: number;
 }
 
 export async function collect({
@@ -93,6 +99,27 @@ export async function lsNominators({
 		api,
 		stashes: stashesParsed,
 	});
+}
+
+export async function commision({
+	ws,
+	percent,
+}: Omit<
+	HandlerArgs,
+	'stashes' | 'stashesFile' | 'suri' | 'eraDepth'
+>): Promise<void> {
+	const provider = new WsProvider(ws);
+	const api = await ApiPromise.create({
+		provider,
+	});
+
+	if (!(typeof percent === 'number')) {
+		console.log('typeof commision', typeof percent);
+		log.warn('Internal error proccessing CLI args');
+		process.exit(1);
+	}
+
+	await commissionData(api, percent);
 }
 
 export function parseStashes(

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 
 import yargs from 'yargs';
 
-import { collect, ls, lsNominators } from './handlers';
+import { collect, commision, ls, lsNominators } from './handlers';
 import { log } from './logger';
 
 async function main() {
@@ -69,6 +69,22 @@ async function main() {
 			{},
 			// @ts-ignore-
 			lsNominators
+		)
+		.command(
+			'commision',
+			'List validators with commission under the given value',
+			// @ts-ignore
+			(yargs) => {
+				return yargs.options({
+					percent: {
+						alias: 'p',
+						description: 'Commision, expressed as a percent i.e "10" for 10%',
+						number: true,
+						demandOption: true,
+					},
+				});
+			},
+			commision
 		)
 		.parse();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@
 
 import yargs from 'yargs';
 
-import { collect, commision, ls, lsNominators } from './handlers';
+import { collect, commission, ls, lsNominators } from './handlers';
 import { log } from './logger';
 
 async function main() {
@@ -71,20 +71,20 @@ async function main() {
 			lsNominators
 		)
 		.command(
-			'commision',
-			'List validators with commission under the given value',
+			'commission',
+			'List validators with commission under and above the given value',
 			// @ts-ignore
 			(yargs) => {
 				return yargs.options({
 					percent: {
 						alias: 'p',
-						description: 'Commision, expressed as a percent i.e "10" for 10%',
+						description: 'Commission, expressed as a percent i.e "10" for 10%',
 						number: true,
 						demandOption: true,
 					},
 				});
 			},
-			commision
+			commission
 		)
 		.parse();
 }


### PR DESCRIPTION
Sample output:

```
payouts commission \
        -w wss://rpc.polkadot.io \
        -p 3
2022-01-23 19:28:18 [payouts] info: average (floor): 65%
2022-01-23 19:28:18 [payouts] info: mean (floor): 3%
2022-01-23 19:28:18 [payouts] info: active validators blocked or commission > 3%: 219
2022-01-23 19:28:18 [payouts] info: active validators with commission <= 3%: 78
2022-01-23 19:28:18 [payouts] info: waiting validators blocked or commission > 3%: 261
2022-01-23 19:28:18 [payouts] info: waiting validators with commission <= 3%: 446
2022-01-23 19:28:18 [payouts] info: Exiting ...