### PR TITLE
Fixes Docker build on latest alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:current-alpine
 
+RUN apk add --no-cache python3 make g++
+
 COPY . /app
 WORKDIR /app
 


### PR DESCRIPTION
NPM requires now python3 make and g++, not optimal since it will increase container size but works